### PR TITLE
ci: make the release workflow safe to trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]*"
+      - "v[0-9]*"
 
 jobs:
   test:
@@ -21,11 +22,21 @@ jobs:
           pip install -r requirements-test.txt
           pip install --no-deps -e .
 
+      - name: Check the tag matches the package version
+        run: |
+          version=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' receita/__init__.py)
+          tag=${GITHUB_REF_NAME#v}
+          echo "tag: $GITHUB_REF_NAME  package version: $version"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match the version $version in receita/__init__.py"
+            exit 1
+          fi
+
       - name: Run tests
         run: pytest tests/ -v
 
   publish:
-    needs: test
+    needs: [test, docker]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -66,7 +77,7 @@ jobs:
           images: leads2b/receita-tools
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The release workflow needed fixing before `3.0.0` is tagged. Each item below would have caused a broken or unrecoverable release.

### The tag pattern did not match this project

The workflow triggered on `v*`, but every tag in this repository is bare: `1.0`, `2.0.2`, `2.0.3`, `2.1.1`, `2.2.0`. Tagging `3.0.0` would have matched nothing and the release would have been silently skipped, with no run and no error. It now triggers on `[0-9]*` and `v[0-9]*`, so either form works.

### The tag was not checked against the packaged version

The version is read from `receita/__init__.py` through `[tool.setuptools.dynamic]`, so the tag has no effect on what gets built. Tagging `v3.0.0-rc1` as a trial run would have uploaded the real `3.0.0` to PyPI, and that version could never be uploaded again. The `test` job now compares the tag against the file and fails before anything is published:

```
v3.0.0     -> allowed
3.0.0      -> allowed
v3.0.1     -> blocked (version is 3.0.0)
v3.0.0-rc1 -> blocked (version is 3.0.0)
```

### The irreversible step could run before the reversible one

`publish` and `docker` both depended only on `test`, so they ran in parallel. If PyPI succeeded and the image push failed, `3.0.0` could not be published again and the only way forward would be a version bump for a problem unrelated to the package. `publish` now depends on `docker`: an image tag can be overwritten, a PyPI version cannot, so the step that cannot be repeated runs last.

### The latest image tag moved for pre-releases

`type=raw,value=latest` applied to any tag, so a pre-release would have become `latest` on Docker Hub. It is now limited to tags without a suffix.